### PR TITLE
Sıcaklık kaydırıcısında Kelvin biriminden ° işareti kaldırıldı. Detaylı bilgi modal'ındaki linklerin rengi düzeltildi

### DIFF
--- a/assets/css/main.scss
+++ b/assets/css/main.scss
@@ -480,6 +480,7 @@
     padding: 15px 20px;
     height: 50vh;
     overflow: auto;
+    a {color:#aa80ff};
   }
 }
 
@@ -492,6 +493,7 @@
     padding: 15px 20px;
     height: 320px;
     overflow: auto;
+    a {color:#aa80ff};
   }
 }
 

--- a/components/Slider.vue
+++ b/components/Slider.vue
@@ -57,7 +57,7 @@ export default {
       temperatureOptions: [
         { label: '°C', value: 'c' },
         { label: '°F', value: 'f' },
-        { label: '°K', value: 'k' },
+        { label: 'K', value: 'k' },
       ],
     }
   },


### PR DESCRIPTION
# Açıklama

<!-- Bu alanda değişiklerinizin ne işe yaradığını ayrıntılı bir biçimde anlatın. -->

**Alakalı Hata (Issue):** Sıcaklık kaydırıcısındaki Kelvin biriminden ° işareti kaldırıldı. Sol menüdeki "detaylı bilgi" butonuyla açılan açıklama sayfasındaki linklerin rengi değiştirildi, okunur hale geldi.

## Değişiklik Tipi

- [x] Hata düzeltimi (belirli bir hatayı (issue) düzelten değişiklikler)
- [ ] Yeni özellik (eklenmiş olan yeni fonksiyonel değişiklikler)
- [ ] Döküman veya yapılandırma dosyaları değişiklikleri

## Ekler
Önce
![Screen Shot 2022-01-20 at 19 01 37](https://user-images.githubusercontent.com/24817072/150375577-2b2af940-e064-4f9a-9f74-d4d2a12b1f1b.png)
Sonra
![Screen Shot 2022-01-20 at 19 01 12](https://user-images.githubusercontent.com/24817072/150375593-e44a97fb-56e4-4699-9df9-7b8948dd4b85.png)

<!-- Yaptığınız değişikliklerin önceki ve sonraki hallerini içeren ekran görüntüleri ve/veya videoları ekleyin. -->

# Kontrol Listesi:

- [x] Kodum bu projenin kod formatı kurallarına uygun.
- [x] Kodumu inceledim.
- [ ] Özellikle anlaşılması güç olabilen alanlar için yorumlar bıraktım.
- [ ] Gerekliyse, dökümanlari güncelledim.
- [x] Değişikliklerim yeni hatalara sebep olmuyor.
- [ ] Değişiklerim doğrultusunda testler ekledim veya testleri güncelledim.
- [ ] Varsa, değişikliklerime bağlı, diğer değişikliklerin tümü hali hazırda ana branch'te mevcut.
