### PR TITLE
Blur Desteklemeyen Tarayıcılara Geçici Çözüm

### DIFF
--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -1187,18 +1187,9 @@ export default {
 }
 
 @supports not (backdrop-filter: blur()) {
-  .sidebar {
-    background-color: rgba(10, 12, 16, 1);
-  }
-
-  .mobile-sidebar {
-    background-color: rgba(10, 12, 16, 1);
-  }
-
-  .oriented-sidebar {
-    background-color: rgba(10, 12, 16, 1);
-  }
-
+  .sidebar,
+  .mobile-sidebar,
+  .oriented-sidebar,
   .close-btn {
     background-color: rgba(10, 12, 16, 1);
   }

--- a/components/SideBar.vue
+++ b/components/SideBar.vue
@@ -1185,4 +1185,22 @@ export default {
   font-size: 12px;
   color: $white;
 }
+
+@supports not (backdrop-filter: blur()) {
+  .sidebar {
+    background-color: rgba(10, 12, 16, 1);
+  }
+
+  .mobile-sidebar {
+    background-color: rgba(10, 12, 16, 1);
+  }
+
+  .oriented-sidebar {
+    background-color: rgba(10, 12, 16, 1);
+  }
+
+  .close-btn {
+    background-color: rgba(10, 12, 16, 1);
+  }
+}
 </style>


### PR DESCRIPTION
# Açıklama

@supports CSS özelliğni ekleyerek blur desteklemeyen tarayıcıların arkaplan saydamlığını 1'e çıkardım. 

https://developer.mozilla.org/en-US/docs/Web/CSS/@supports

**Alakalı Hata (Issue):** #48  
 
Tam olarak istenilen çözüm bu mu emin değilim ama alternatifi bulunana kadar uygulamanın blur desteklemeyen tarayıcılarda kullanılmasını sağlayabilir.

## Ekler
Öncesi:
![Screenshot 2022-01-22 at 17-46-03 Periodum](https://user-images.githubusercontent.com/69052962/150643275-86fc072c-cab7-470a-bba3-06a0c5d0e574.png)

Sonrası:
![Screenshot 2022-01-22 at 17-46-34 Periodum](https://user-images.githubusercontent.com/69052962/150643291-2909364d-696c-4bc0-8b98-4bdd44fb7d16.png)
