### PR TITLE
Add iPad and macOS client repository to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ This project started as a Turkish periodic table; however, we are now at a point
 - **Periodum Periodic Table (Latest Version):** https://periodum.com/
 - **Project Needs & Roadmap:** https://github.com/evrimagaci/periodum/projects/1
 - **Design File:** https://dar.vin/4Ksrj _You can access the design file using [Sketch](https://www.sketch.com/) or [Adobe XD](https://www.adobe.com/products/xd.html)._
+- **iPad and macOS Client:** https://github.com/umurgdk/periodum-apple
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This project started as a Turkish periodic table; however, we are now at a point
 - **Periodum Periodic Table (Latest Version):** https://periodum.com/
 - **Project Needs & Roadmap:** https://github.com/evrimagaci/periodum/projects/1
 - **Design File:** https://dar.vin/4Ksrj _You can access the design file using [Sketch](https://www.sketch.com/) or [Adobe XD](https://www.adobe.com/products/xd.html)._
-- **iPad and macOS Client:** https://github.com/umurgdk/periodum-apple
+- **iPad and macOS Client:** https://github.com/evrimagaci/periodum-apple
 
 ## Installation
 


### PR DESCRIPTION
# Açıklama

Apple platforms porting is still in progress. At the moment only the periodic table layout and element inspector (sidebar) and unit conversions are working. I will be continue porting compounds and other features available on https://periodum.com. 

Maybe @evrimagaci can fork my repository so we can potentially have other contributors maybe?

Repository address: https://github.com/umurgdk/periodum-apple

## Değişiklik Tipi

- [ ] Hata düzeltimi (belirli bir hatayı (issue) düzelten değişiklikler)
- [ ] Yeni özellik (eklenmiş olan yeni fonksiyonel değişiklikler)
- [x] Döküman veya yapılandırma dosyaları değişiklikleri

## Ekler

<img width="1160" alt="Screen Shot 2022-01-29 at 03 45 34" src="https://user-images.githubusercontent.com/624974/151640210-3348c7bb-2d52-4dec-99ee-e8edaf355293.png">
