### PR TITLE
fix: Fixed scrolling bug in the Loading Component

### DIFF
--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -1,5 +1,5 @@
 <template>
-  <div class="loading" v-html="PeriodumLoadingSvg" />
+  <div scroll="no" class="loading" v-html="PeriodumLoadingSvg" />
 </template>
 
 <script>
@@ -23,6 +23,8 @@ export default {
   width: 100vw;
   height: 100vh;
   position: absolute;
+  overflow-x: hidden;
+  overflow-y: hidden;
   overflow: hidden;
   top: 0;
   left: 0;

--- a/components/Loading.vue
+++ b/components/Loading.vue
@@ -23,6 +23,7 @@ export default {
   width: 100vw;
   height: 100vh;
   position: absolute;
+  overflow: hidden;
   top: 0;
   left: 0;
   z-index: 9999;


### PR DESCRIPTION
# Explanation
Fixed the Scrollbar being open on the loading screen and seeing a portion of the site below the loading bar when the user scrolls. Little important changes.

**Related Issue:** #

## Change Category:

- [x] Bug Fix
- [ ] Feature
- [ ] Documentation

## Aditional Information:

![](https://media.discordapp.net/attachments/775822548519616562/984830971125829662/unknown.png?width=936&height=468)

# How to test?

- [x] Tested Loading Page in "/" 

# Checklist:

- [x] My code complies with this project's code formatting guidelines.
- [x] I reviewed my code.
- [x] I added comments especially in portions that may be difficult to understand.
- [x] If necessary, I updated the documentation.
- [x] Changes I made do not produce new issues.
- [x] I added or updated tests based on my changes.
- [x] If any, all changes related to my changes are already present in the main branch.
